### PR TITLE
Fix call to pyreadstat set_value_labels

### DIFF
--- a/spss_converter/write.py
+++ b/spss_converter/write.py
@@ -399,5 +399,5 @@ def apply_metadata(df: DataFrame,
     as_pyreadstat = metadata.to_pyreadstat()
 
     return pyreadstat.set_value_labels(df,
-                                       metadata = as_pyreadstat.value_labels,
+                                       metadata = as_pyreadstat,
                                        formats_as_category = as_category)


### PR DESCRIPTION
despite the docs stating the contrary, this accepts a metadata_container, not a dict.